### PR TITLE
Refine k-reuse recovery payload and UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -465,7 +465,9 @@ function showRecoveryModal(data, isSuccess) {
     let copyTargetEscaped = '';
     if (isSuccess) {
         const successData = data?.successful_recovery || {};
-        const privateKeyWif = successData.private_key_wif || 'Unavailable';
+        const privateKeyWifRaw = successData.private_key_wif;
+        const hasPrivateKeyWif = typeof privateKeyWifRaw === 'string' && privateKeyWifRaw.trim().length > 0;
+        const privateKeyWif = hasPrivateKeyWif ? privateKeyWifRaw : 'Unavailable';
         const privateKeyHex = successData.private_key_hex || successData.validation_result?.private_key_hex || 'Unavailable';
         const attackMethod = successData.attack_method || 'ECDSA nonce reuse';
         const recoveryPair = successData.recovery_pair?.transactions || successData.transaction_ids || [];
@@ -483,8 +485,8 @@ function showRecoveryModal(data, isSuccess) {
         const addressesHtml = addressEntries.length
             ? addressEntries.map(([type, addr]) => `<div><strong>${type}:</strong> <code>${addr}</code></div>`).join('')
             : '<em>No derived addresses available.</em>';
-        copyTarget = privateKeyWif && typeof privateKeyWif === 'string' ? privateKeyWif : '';
-        copyTargetEscaped = copyTarget.replace(/'/g, "\\'");
+        copyTarget = hasPrivateKeyWif ? privateKeyWifRaw : '';
+        copyTargetEscaped = copyTarget ? copyTarget.replace(/'/g, "\\'") : '';
 
         content = `
             <div class="mb-3">

--- a/static/app.js
+++ b/static/app.js
@@ -461,6 +461,8 @@ function showRecoveryModal(data, isSuccess) {
     const modalClass = isSuccess ? 'border-success' : 'border-danger';
 
     let content = '';
+    let copyTarget = '';
+    let copyTargetEscaped = '';
     if (isSuccess) {
         const successData = data?.successful_recovery || {};
         const privateKeyWif = successData.private_key_wif || 'Unavailable';
@@ -481,8 +483,8 @@ function showRecoveryModal(data, isSuccess) {
         const addressesHtml = addressEntries.length
             ? addressEntries.map(([type, addr]) => `<div><strong>${type}:</strong> <code>${addr}</code></div>`).join('')
             : '<em>No derived addresses available.</em>';
-        const copyTarget = privateKeyWif && typeof privateKeyWif === 'string' ? privateKeyWif : '';
-        const copyTargetEscaped = copyTarget.replace(/'/g, "\\'");
+        copyTarget = privateKeyWif && typeof privateKeyWif === 'string' ? privateKeyWif : '';
+        copyTargetEscaped = copyTarget.replace(/'/g, "\\'");
 
         content = `
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- enrich the `/test_manual_recovery` response with derived metadata for the first successful attempt while retaining the attempt list
- compute nonce, address, and block context details so the frontend can render recovery information without undefined fields
- update the recovery modal logic to consume the structured payload and present graceful fallbacks when no private key is recovered

## Testing
- python - <<'PY' \u2026 (monkey-patched test client request)


------
https://chatgpt.com/codex/tasks/task_e_68f8ba26fdb8832884436bb705378c1f