### PR TITLE
Fix SQLAlchemy base import compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from flask import Flask, render_template, request, jsonify, flash, redirect, url
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.middleware.proxy_fix import ProxyFix
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text, Float, Boolean
-from sqlalchemy.orm import sessionmaker, DeclarativeBase
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import SQLAlchemyError
 import base58
 from dotenv import load_dotenv
@@ -34,8 +34,6 @@ from config import Config
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
-class Base(DeclarativeBase):
-    pass
 db = SQLAlchemy()
 
 # Create Flask app


### PR DESCRIPTION
## Summary
- remove the unused SQLAlchemy DeclarativeBase dependency so the app starts on environments without SQLAlchemy 2.0

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_6909eca870b08328b9c6200ac1559b7a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bakaxbaka/cryptoautopilot/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->